### PR TITLE
Update build file to include --no-db option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.vagrant
 .phpunit.result.cache
 .env
+composer.lock


### PR DESCRIPTION
This PR updates the build output to include the changes to ignore db creation as the current binary does not support this option. I have also included a gitignore update to include the composer.lock file that was removed in the last commit.