### PR TITLE
Chore: Support no-deploy flag

### DIFF
--- a/app/Commands/DeployCommand.php
+++ b/app/Commands/DeployCommand.php
@@ -71,9 +71,11 @@ class DeployCommand extends Command
             $forge->updateSiteEnvironmentFile($server->id, $site->id, $envSource);
         }
 
-        $this->information('Deploying');
+        if (! $this->option('no-deploy')) {
+            $this->information('Deploying');
 
-        $site->deploySite();
+            $site->deploySite();
+        }
 
         foreach ($this->option('command') as $i => $command) {
             if ($i === 0) {


### PR DESCRIPTION
It would appear as though nothing actually checks for the `--no-deploy` flag, so this always happens regardless.
